### PR TITLE
Add support for loading additional image formats

### DIFF
--- a/Main.tscn
+++ b/Main.tscn
@@ -893,7 +893,7 @@ window_title = "Open File(s)"
 resizable = true
 mode = 1
 access = 2
-filters = PoolStringArray( "*jpg, *.png ; JPG, PNG Images" )
+filters = PoolStringArray( "*.bmp ; BMP Image", "*.hdr ; Radiance HDR Image", "*.jpg,*.jpeg ; JPEG Image", "*.png ; PNG Image", "*.tga ; TGA Image", "*.webp ; WebP Image" )
 current_dir = "/home/danielnaoexiste/Documents/Prog/Pixelorama"
 current_path = "/home/danielnaoexiste/Documents/Prog/Pixelorama/"
 


### PR DESCRIPTION
This also makes it possible to load JPEG images if they have a `.jpeg` extension.

See also https://github.com/RodZill4/godot-procedural-textures/pull/35.

We should update the README as well once a new release is made :slightly_smiling_face: