### PR TITLE
Add support for importing SVG images

### DIFF
--- a/Main.tscn
+++ b/Main.tscn
@@ -893,7 +893,7 @@ window_title = "Open File(s)"
 resizable = true
 mode = 1
 access = 2
-filters = PoolStringArray( "*.bmp ; BMP Image", "*.hdr ; Radiance HDR Image", "*.jpg,*.jpeg ; JPEG Image", "*.png ; PNG Image", "*.tga ; TGA Image", "*.webp ; WebP Image" )
+filters = PoolStringArray( "*.bmp ; BMP Image", "*.hdr ; Radiance HDR Image", "*.jpg,*.jpeg ; JPEG Image", "*.png ; PNG Image", "*.svg ; SVG Image", "*.tga ; TGA Image", "*.webp ; WebP Image" )
 current_dir = "/home/danielnaoexiste/Documents/Prog/Pixelorama"
 current_path = "/home/danielnaoexiste/Documents/Prog/Pixelorama/"
 


### PR DESCRIPTION
This makes use of Godot's SVG importer to load SVGs and rasterize them.

Not sure how useful this will be in a pixel art context, but I guess it doesn't hurt to expose it.

See also https://github.com/RodZill4/godot-procedural-textures/pull/49.