### PR TITLE
Implement fullscreen toggle by pressing F11 or Alt + Enter

### DIFF
--- a/Scripts/Main.gd
+++ b/Scripts/Main.gd
@@ -123,6 +123,9 @@ func _ready() -> void:
 	Global.brushes_from_files = Global.custom_brushes.size()
 
 func _input(event):
+	if event.is_action_pressed("toggle_fullscreen"):
+		OS.window_fullscreen = !OS.window_fullscreen
+
 	if Global.has_focus:
 		for t in tools: #Handle tool shortcuts
 			if event.is_action_pressed(t[2]): #Shortcut for right button (with Alt)

--- a/project.godot
+++ b/project.godot
@@ -165,6 +165,12 @@ right_lightdark_tool={
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":true,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":85,"unicode":0,"echo":false,"script":null)
  ]
 }
+toggle_fullscreen={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777254,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":true,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777221,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [rendering]
 


### PR DESCRIPTION
This makes it possible to make the window fullscreen without using external tools.