### PR TITLE
Improve the status bar display

### DIFF
--- a/Main.tscn
+++ b/Main.tscn
@@ -102,19 +102,22 @@ anchor_right = 0.5
 anchor_bottom = 1.0
 margin_left = -65.5
 margin_right = 65.5
+custom_constants/separation = 20
 
 [node name="ZoomLevel" type="Label" parent="MenuAndUI/MenuContainer/HBoxContainer"]
 margin_top = 7.0
-margin_right = 80.0
+margin_right = 60.0
 margin_bottom = 21.0
-text = "Zoom: x7.81"
+rect_min_size = Vector2( 60, 0 )
+text = "781 %"
+align = 2
 
 [node name="CursorPosition" type="Label" parent="MenuAndUI/MenuContainer/HBoxContainer"]
-margin_left = 84.0
+margin_left = 80.0
 margin_top = 7.0
-margin_right = 131.0
+margin_right = 128.0
 margin_bottom = 21.0
-text = "[64x64]"
+text = "[64×64]"
 align = 2
 
 [node name="UI" type="HBoxContainer" parent="MenuAndUI"]

--- a/Scripts/CameraMovement.gd
+++ b/Scripts/CameraMovement.gd
@@ -34,4 +34,4 @@ func zoom_camera(dir : int) -> void:
 	if zoom > zoom_max:
 		zoom = zoom_max
 	if name == "Camera2D":
-		Global.zoom_level_label.text = "Zoom: x%s" % [stepify(1 / zoom.x, 0.01)]
+		Global.zoom_level_label.text = str(round(100 / Global.camera.zoom.x)) + " %"

--- a/Scripts/Canvas.gd
+++ b/Scripts/Canvas.gd
@@ -66,7 +66,7 @@ func camera_zoom() -> void:
 		Global.camera2.zoom_max = Vector2.ONE
 	Global.camera.zoom = Vector2(bigger, bigger) * 0.002
 	Global.camera2.zoom = Vector2(bigger, bigger) * 0.002
-	Global.zoom_level_label.text = "Zoom: x%s" % [stepify(1 / Global.camera.zoom.x, 0.01)]
+	Global.zoom_level_label.text = str(round(100 / Global.camera.zoom.x)) + " %"
 
 	#Set camera offset to the center of canvas
 	Global.camera.offset = size / 2
@@ -95,9 +95,9 @@ func _process(delta) -> void:
 			if !Input.is_mouse_button_pressed(BUTTON_LEFT) && !Input.is_mouse_button_pressed(BUTTON_RIGHT):
 				if mouse_inside_canvas:
 					mouse_inside_canvas = false
-			Global.cursor_position_label.text = "[%sx%s]" % [size.x, size.y]
+			Global.cursor_position_label.text = "[%s×%s]" % [size.x, size.y]
 		else:
-			Global.cursor_position_label.text = "[%sx%s] %s, %s" % [size.x, size.y, mouse_pos_floored.x, mouse_pos_floored.y]
+			Global.cursor_position_label.text = "[%s×%s]    %s, %s" % [size.x, size.y, mouse_pos_floored.x, mouse_pos_floored.y]
 
 
 	#Handle Undo/Redo


### PR DESCRIPTION
- Display zoom as a percentage, to be more in line with other 2D editing applications.
- Increase spacing between labels.
- Use the Unicode multiplication sign.

## Preview

![Status bar](https://user-images.githubusercontent.com/180032/69360102-402e0780-0c8a-11ea-8ec0-c7aca614dc9d.png)